### PR TITLE
use Q promise for mongoose

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -13,6 +13,9 @@ module.exports = (grunt) ->
   grunt.initConfig
     bump:
       options:
+        commitFiles: ['-a']
+        files: ['package.json']
+        prereleaseName: 'alpha'
         pushTo: 'origin'
 
     clean: ['lib/']

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "lodash": "^3.10.1",
     "mongoose": "^4.1.3",
+    "q": "1.4.1",
     "sinon": "^1.15.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-sinon",
-  "version": "0.0.3",
+  "version": "0.0.4-alpha.0",
   "description": "Convenient sinon stubs for all your mongoose model and document methods.",
   "main": "index.js",
   "scripts": {

--- a/src/mock-query.coffee
+++ b/src/mock-query.coffee
@@ -1,4 +1,5 @@
 mongoose = require 'mongoose'
+mongoose.Promise = require('q').Promise
 _ = require 'lodash'
 
 class MockQuery


### PR DESCRIPTION
connect https://github.com/waffleio/waffle.io/issues/2746

Due to Semver and a lack of a shrinkwrap, we are pulling in the latest mongoose (currently 4.7.1) which has a deprecation warning around not using mpromises anymore.

For more info - http://mongoosejs.com/docs/promises.html